### PR TITLE
Fixed an error for describe command when more than three nested cop class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Fixed
+
+- Fixed an error for describe command when more than three nested cop class.
+
 ## 0.11.0 - 2022-07-29
 
 ### Changed

--- a/lib/rubocop_todo_corrector/cop_source_detector.rb
+++ b/lib/rubocop_todo_corrector/cop_source_detector.rb
@@ -45,7 +45,7 @@ module RubocopTodoCorrector
 
     # @return [String]
     def cop_class_name
-      "RuboCop::Cop::#{@cop_name.sub('/', '::')}"
+      "RuboCop::Cop::#{@cop_name.gsub('/', '::')}"
     end
   end
 end


### PR DESCRIPTION
This PR is fixed an error for describe command when more than three nested cop class.

For example, the following error occurs for [RSpec/Rails/HaveHttpStatus](https://docs.rubocop.org/rubocop-rspec/cops_rspec_rails.html#rspecrailshavehttpstatus).
```
-e:1:in `const_source_location': wrong constant name Rails/HaveHttpStatus (NameError)

Bundler.require; print Object.const_source_location("RuboCop::Cop::RSpec::Rails/HaveHttpStatus").first
                             ^^^^^^^^^^^^^^^^^^^^^^
	from -e:1:in `<main>'
Switched to a new branch 'rubocop-todo-corrector-2785051892'
Aborting commit due to empty commit message.
Error: Process completed with exit code 1.
```