### PR TITLE
Support `inherit_gem` directive

### DIFF
--- a/lib/rubocop_todo_corrector/bundle_installer.rb
+++ b/lib/rubocop_todo_corrector/bundle_installer.rb
@@ -51,10 +51,12 @@ module RubocopTodoCorrector
       [
         "source 'https://rubygems.org'",
         *@gem_specifications.map do |gem_specification|
-          format(
-            "gem '%<gem_name>s', '%<gem_version>s'",
-            gem_specification
-          )
+          case gem_specification
+          in gem_version: nil
+            format("gem '%<gem_name>s'", gem_specification)
+          else
+            format("gem '%<gem_name>s', '%<gem_version>s'", gem_specification)
+          end
         end
       ].join("\n") << "\n"
     end

--- a/lib/rubocop_todo_corrector/gem_names_detector.rb
+++ b/lib/rubocop_todo_corrector/gem_names_detector.rb
@@ -29,12 +29,17 @@ module RubocopTodoCorrector
 
     # @return [Array<String>]
     def gem_names
-      requires.grep(/\A[\w-]+\z/)
+      requires.grep(/\A[\w-]+\z/) + inherit_gems
     end
 
     # @return [Array<String>]
     def requires
       configuration_hash['require'] || []
+    end
+
+    # @return [Array<String>]
+    def inherit_gems
+      configuration_hash['inherit_gem']&.keys || []
     end
   end
 end

--- a/spec/fixtures/dummy_rubocop.yml
+++ b/spec/fixtures/dummy_rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  rubocop-rails-omakase: rubocop.yml
+
 require:
   - rubocop-rake
   - rubocop-rspec

--- a/spec/rubocop_todo_corrector/commands/describe_spec.rb
+++ b/spec/rubocop_todo_corrector/commands/describe_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RubocopTodoCorrector::Commands::Describe do
     subject do
       described_class.call(
         cop_name:,
-        temporary_gemfile_path: 'tmp/Gemfile_rubocop_todo_corrector.rb'
+        temporary_gemfile_path: 'Gemfile'
       )
     end
 

--- a/spec/rubocop_todo_corrector/gem_names_detector_spec.rb
+++ b/spec/rubocop_todo_corrector/gem_names_detector_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe RubocopTodoCorrector::GemNamesDetector do
         %w[
           rubocop-rake
           rubocop-rspec
+          rubocop-rails-omakase
         ]
       )
     end


### PR DESCRIPTION
This PR makes rubocop.yml which contains `inherit_gem` directive compatible with this gem and the custom action on top of it.

Currently the config which contains these lines does not work:

```
inherit_from: .rubocop_todo.yml

inherit_gem:
  rubocop-rails-omakase: rubocop.yml
```

This is the workflow definition which we have attempted;

```
name: rubocop-todo-corrector

on:
  pull_request:
    types:
      - closed
  workflow_dispatch:
    inputs:
      cop_name:
        description: Pass cop name if you want to pick a specific cop.
        required: false
        type: string

jobs:
  run:
    runs-on: ubuntu-latest
    permissions:
      contents: write
      pull-requests: write
    steps:
      - uses: r7kamura/rubocop-todo-corrector@v0
        with:
          cop_name: ${{ inputs.cop_name }}
          github_token: ${{ secrets.GITHUB_TOKEN }}
          label: rubocop-todo-corrector
```

and this is the error it produced:

```
Unable to find gem rubocop-rails-omakase; is the gem installed? Gem::MissingSpecError
```

---

It was pretty intuitive that GemNamesDetector was where to patch (and I thank you about it!), but testing the changes in accordance with bundler was a true hard part, about which I wrote up in the second commit. Let me know if anything seems to be missing! Thank you in advance 🙂 