### PR TITLE
Add plugins support

### DIFF
--- a/lib/rubocop_todo_corrector/gem_names_detector.rb
+++ b/lib/rubocop_todo_corrector/gem_names_detector.rb
@@ -29,7 +29,12 @@ module RubocopTodoCorrector
 
     # @return [Array<String>]
     def gem_names
-      requires.grep(/\A[\w-]+\z/) + inherit_gems
+      requires.grep(/\A[\w-]+\z/) + plugins + inherit_gems
+    end
+
+    # @return [Array<String>]
+    def plugins
+      configuration_hash['plugins'] || []
     end
 
     # @return [Array<String>]

--- a/spec/fixtures/dummy_rubocop.yml
+++ b/spec/fixtures/dummy_rubocop.yml
@@ -1,6 +1,6 @@
 inherit_gem:
   rubocop-rails-omakase: rubocop.yml
 
-require:
+plugins:
   - rubocop-rake
   - rubocop-rspec


### PR DESCRIPTION
Starting from RuboCop 1.72, a new mechanism utilizing the plugins property has been introduced. Due to this change, if no action is taken, attempting to run rubocop_todo_corrector on RuboCop 1.72 or later will result in failure.