### PR TITLE
Add missing `require 'shellwords'`

### DIFF
--- a/lib/rubocop_todo_corrector/commands/apply.rb
+++ b/lib/rubocop_todo_corrector/commands/apply.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'pathname'
+require 'shellwords'
 require 'yaml'
 
 module RubocopTodoCorrector


### PR DESCRIPTION
- Fix https://github.com/r7kamura/rubocop_todo_corrector/issues/36

I couldn’t reproduce it on my local machine, but perhaps the execution environment affects whether `shellwords` gets required or not.
